### PR TITLE
Add children to taxonomies

### DIFF
--- a/backend/src/api/taxonomy/types/taxonomy.js
+++ b/backend/src/api/taxonomy/types/taxonomy.js
@@ -5,6 +5,7 @@ const schema = `
     id: String!
     name: String
     parent: [Taxonomy!]
+    children: [Taxonomy!]
     createdAt: DateTime
     updatedAt: DateTime
   }

--- a/backend/src/api/taxonomy/types/taxonomy.js
+++ b/backend/src/api/taxonomy/types/taxonomy.js
@@ -5,7 +5,7 @@ const schema = `
     id: String!
     name: String
     parent: [Taxonomy!]
-    children: [Taxonomy!]
+    subtaxonomies: [Taxonomy!]
     createdAt: DateTime
     updatedAt: DateTime
   }

--- a/backend/src/api/taxonomy/types/taxonomyFilterInput.js
+++ b/backend/src/api/taxonomy/types/taxonomyFilterInput.js
@@ -3,6 +3,7 @@ const schema = `
     id: String
     name: String
     parent: [String!]
+    children: [String!]
     status: TaxonomyStatusEnum
     createdAtRange: [ DateTime ]
   }

--- a/backend/src/api/taxonomy/types/taxonomyFilterInput.js
+++ b/backend/src/api/taxonomy/types/taxonomyFilterInput.js
@@ -3,7 +3,7 @@ const schema = `
     id: String
     name: String
     parent: [String!]
-    children: [String!]
+    subtaxonomies: [String!]
     status: TaxonomyStatusEnum
     createdAtRange: [ DateTime ]
   }

--- a/backend/src/api/taxonomy/types/taxonomyInput.js
+++ b/backend/src/api/taxonomy/types/taxonomyInput.js
@@ -2,6 +2,7 @@ const schema = `
   input TaxonomyInput {
     name: String!
     parent: [String!]
+    children: [String!]
   }
 `;
 

--- a/backend/src/api/taxonomy/types/taxonomyInput.js
+++ b/backend/src/api/taxonomy/types/taxonomyInput.js
@@ -2,7 +2,7 @@ const schema = `
   input TaxonomyInput {
     name: String!
     parent: [String!]
-    children: [String!]
+    subtaxonomies: [String!]
   }
 `;
 

--- a/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
+++ b/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
@@ -6,8 +6,8 @@ const schema = `
     name_DESC
     parent_ASC
     parent_DESC
-    children_ASC
-    children_DESC
+    subtaxonomies_ASC
+    subtaxonomies_DESC
     status_ASC
     status_DESC
     createdAt_ASC

--- a/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
+++ b/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
@@ -3,7 +3,7 @@ const schema = `
     id_ASC
     id_DESC
     name_ASC
-    name_DES
+    name_DESC
     parent_ASC
     parent_DESC
     children_ASC

--- a/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
+++ b/backend/src/api/taxonomy/types/taxonomyOrderByEnum.js
@@ -6,6 +6,8 @@ const schema = `
     name_DES
     parent_ASC
     parent_DESC
+    children_ASC
+    children_DESC
     status_ASC
     status_DESC
     createdAt_ASC

--- a/backend/src/database/models/taxonomy.js
+++ b/backend/src/database/models/taxonomy.js
@@ -17,7 +17,7 @@ const TaxonomySchema = new Schema(
         // ref: 'taxonomy',
       },
     ],
-    children: [
+    subtaxonomies: [
       {
         type: Schema.Types.ObjectId,
         // ref: 'taxonomy',

--- a/backend/src/database/models/taxonomy.js
+++ b/backend/src/database/models/taxonomy.js
@@ -17,6 +17,12 @@ const TaxonomySchema = new Schema(
         // ref: 'taxonomy',
       },
     ],
+    children: [
+      {
+        type: Schema.Types.ObjectId,
+        // ref: 'taxonomy',
+      },
+    ],
   }
 );
 

--- a/backend/src/database/repositories/taxonomyRepository.js
+++ b/backend/src/database/repositories/taxonomyRepository.js
@@ -148,7 +148,8 @@ class TaxonomyRepository {
   async findById(id, options) {
     return MongooseRepository.wrapWithSessionIfExists(
       Taxonomy.findById(id)
-        .populate('parent'),
+        .populate('parent')
+        .populate('children'),
       options,
     );
   }
@@ -162,6 +163,7 @@ class TaxonomyRepository {
   async findByIds(ids, options) {
     return MongooseRepository.wrapWithSessionIfExists(
       Taxonomy.find({ _id: { $in: ids } }).populate('parent'),
+      Taxonomy.find({ _id: { $in: ids } }).populate('children'),
       options,
     );
   }
@@ -225,6 +227,14 @@ class TaxonomyRepository {
         };
       }
 
+      // TODO fix filtering on children
+      if (filter.children) {
+        criteria = {
+          ...criteria,
+          children: filter.children,
+        };
+      }
+
       if (filter.createdAtRange) {
         const [start, end] = filter.createdAtRange;
 
@@ -269,7 +279,8 @@ class TaxonomyRepository {
       .skip(skip)
       .limit(limitEscaped)
       .sort(sort)
-      .populate('parent');
+      .populate('parent')
+      .populate('children');
 
     const count = await Taxonomy.countDocuments(criteria);
 

--- a/backend/src/database/repositories/taxonomyRepository.js
+++ b/backend/src/database/repositories/taxonomyRepository.js
@@ -149,7 +149,7 @@ class TaxonomyRepository {
     return MongooseRepository.wrapWithSessionIfExists(
       Taxonomy.findById(id)
         .populate('parent')
-        .populate('children'),
+        .populate('subtaxonomies'),
       options,
     );
   }
@@ -163,7 +163,7 @@ class TaxonomyRepository {
   async findByIds(ids, options) {
     return MongooseRepository.wrapWithSessionIfExists(
       Taxonomy.find({ _id: { $in: ids } }).populate('parent'),
-      Taxonomy.find({ _id: { $in: ids } }).populate('children'),
+      Taxonomy.find({ _id: { $in: ids } }).populate('subtaxonomies'),
       options,
     );
   }
@@ -227,11 +227,11 @@ class TaxonomyRepository {
         };
       }
 
-      // TODO fix filtering on children
-      if (filter.children) {
+      // TODO fix filtering on subtaxonomies
+      if (filter.subtaxonomies) {
         criteria = {
           ...criteria,
-          children: filter.children,
+          subtaxonomies: filter.subtaxonomies,
         };
       }
 
@@ -280,7 +280,7 @@ class TaxonomyRepository {
       .limit(limitEscaped)
       .sort(sort)
       .populate('parent')
-      .populate('children');
+      .populate('subtaxonomies');
 
     const count = await Taxonomy.countDocuments(criteria);
 

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -610,7 +610,7 @@ const en = {
       fields: {
         id: 'Id',
         parent: 'Parent',
-        children: 'Children',
+        subtaxonomies: 'Children',
         name: 'Name',
         status: 'Status',
         createdAt: 'Created at',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -610,6 +610,7 @@ const en = {
       fields: {
         id: 'Id',
         parent: 'Parent',
+        children: 'Children',
         name: 'Name',
         status: 'Status',
         createdAt: 'Created at',

--- a/frontend/src/i18n/no-NO.js
+++ b/frontend/src/i18n/no-NO.js
@@ -610,6 +610,7 @@ const no = {
       fields: {
         id: 'Id',
         parent: 'Forelder',
+        subtaxonomies: 'Barn',
         name: 'Navn',
         status: 'Status',
         createdAt: 'Opprettet',

--- a/frontend/src/modules/taxonomy/importer/taxonomyImporterFields.js
+++ b/frontend/src/modules/taxonomy/importer/taxonomyImporterFields.js
@@ -6,4 +6,5 @@ export default [
   // fields.status,
   fields.name,
   fields.parent,
+  fields.children,
 ];

--- a/frontend/src/modules/taxonomy/importer/taxonomyImporterFields.js
+++ b/frontend/src/modules/taxonomy/importer/taxonomyImporterFields.js
@@ -6,5 +6,5 @@ export default [
   // fields.status,
   fields.name,
   fields.parent,
-  fields.children,
+  fields.subtaxonomies,
 ];

--- a/frontend/src/modules/taxonomy/list/taxonomyListExporterFields.js
+++ b/frontend/src/modules/taxonomy/list/taxonomyListExporterFields.js
@@ -7,7 +7,7 @@ export default [
   // fields.status,
   fields.name,
   fields.parent,
-  fields.children,
+  fields.subtaxonomies,
   fields.createdAt,
   fields.updatedAt
 ];

--- a/frontend/src/modules/taxonomy/list/taxonomyListExporterFields.js
+++ b/frontend/src/modules/taxonomy/list/taxonomyListExporterFields.js
@@ -7,6 +7,7 @@ export default [
   // fields.status,
   fields.name,
   fields.parent,
+  fields.children,
   fields.createdAt,
   fields.updatedAt
 ];

--- a/frontend/src/modules/taxonomy/taxonomyModel.js
+++ b/frontend/src/modules/taxonomy/taxonomyModel.js
@@ -40,9 +40,9 @@ const fields = {
     label('parent'),
     {},
   ),
-  children: new RelationToManyField(
-    'children',
-    label('children'),
+  subtaxonomies: new RelationToManyField(
+    'subtaxonomies',
+    label('subtaxonomies'),
     {},
   ),
   createdAt: new DateTimeField(

--- a/frontend/src/modules/taxonomy/taxonomyModel.js
+++ b/frontend/src/modules/taxonomy/taxonomyModel.js
@@ -40,6 +40,11 @@ const fields = {
     label('parent'),
     {},
   ),
+  children: new RelationToManyField(
+    'children',
+    label('children'),
+    {},
+  ),
   createdAt: new DateTimeField(
     'createdAt',
     label('createdAt'),

--- a/frontend/src/modules/taxonomy/taxonomyService.js
+++ b/frontend/src/modules/taxonomy/taxonomyService.js
@@ -89,6 +89,10 @@ export default class TaxonomyService {
               id
               name
             }
+            children {
+              id
+              name
+            }
             createdAt
             updatedAt
           }
@@ -123,6 +127,10 @@ export default class TaxonomyService {
               id
               name
               parent {
+                id
+                name
+              }
+              children {
                 id
                 name
               }

--- a/frontend/src/modules/taxonomy/taxonomyService.js
+++ b/frontend/src/modules/taxonomy/taxonomyService.js
@@ -89,7 +89,7 @@ export default class TaxonomyService {
               id
               name
             }
-            children {
+            subtaxonomies {
               id
               name
             }
@@ -108,7 +108,7 @@ export default class TaxonomyService {
   }
 
   static async list(filter, orderBy, limit, offset) {
-    let response = await graphqlClient.query({
+    const response = await graphqlClient.query({
       query: gql`
         query TAXONOMY_LIST(
           $filter: TaxonomyFilterInput
@@ -130,7 +130,7 @@ export default class TaxonomyService {
                 id
                 name
               }
-              children {
+              subtaxonomies {
                 id
                 name
               }
@@ -148,15 +148,7 @@ export default class TaxonomyService {
         offset,
       },
     });
-      
-    // Temporary fix for avoiding unnecessary expandable rows
-    // because children is a reserved attribute name
-    response.data.taxonomyList.rows = response.data.taxonomyList.rows.map(tax => {
-      tax.subtaxonomies = tax.children;
-      tax.children = [];
-      return tax;
-    });
-
+    
     return response.data.taxonomyList;
   }
 

--- a/frontend/src/modules/taxonomy/taxonomyService.js
+++ b/frontend/src/modules/taxonomy/taxonomyService.js
@@ -108,7 +108,7 @@ export default class TaxonomyService {
   }
 
   static async list(filter, orderBy, limit, offset) {
-    const response = await graphqlClient.query({
+    let response = await graphqlClient.query({
       query: gql`
         query TAXONOMY_LIST(
           $filter: TaxonomyFilterInput
@@ -147,6 +147,14 @@ export default class TaxonomyService {
         limit,
         offset,
       },
+    });
+      
+    // Temporary fix for avoiding unnecessary expandable rows
+    // because children is a reserved attribute name
+    response.data.taxonomyList.rows = response.data.taxonomyList.rows.map(tax => {
+      tax.subtaxonomies = tax.children;
+      tax.children = [];
+      return tax;
     });
 
     return response.data.taxonomyList;

--- a/frontend/src/view/taxonomy/form/TaxonomyForm.js
+++ b/frontend/src/view/taxonomy/form/TaxonomyForm.js
@@ -19,7 +19,7 @@ class TaxonomyForm extends Component {
     fields.name,
     // fields.status,
     fields.parent,
-    fields.children,
+    fields.subtaxonomies,
   ]);
 
   handleSubmit = (values) => {
@@ -82,9 +82,9 @@ class TaxonomyForm extends Component {
                       mode="multiple"
                     />
                     <TaxonomyAutocompleteFormItem
-                      name={fields.children.name}
-                      label={fields.children.label}
-                      required={fields.children.required}
+                      name={fields.subtaxonomies.name}
+                      label={fields.subtaxonomies.label}
+                      required={fields.subtaxonomies.required}
                       showCreate={!this.props.modal}
                       form={form}
                       mode="multiple"

--- a/frontend/src/view/taxonomy/form/TaxonomyForm.js
+++ b/frontend/src/view/taxonomy/form/TaxonomyForm.js
@@ -19,6 +19,7 @@ class TaxonomyForm extends Component {
     fields.name,
     // fields.status,
     fields.parent,
+    fields.children,
   ]);
 
   handleSubmit = (values) => {
@@ -76,6 +77,14 @@ class TaxonomyForm extends Component {
                       name={fields.parent.name}
                       label={fields.parent.label}
                       required={fields.parent.required}
+                      showCreate={!this.props.modal}
+                      form={form}
+                      mode="multiple"
+                    />
+                    <TaxonomyAutocompleteFormItem
+                      name={fields.children.name}
+                      label={fields.children.label}
+                      required={fields.children.required}
                       showCreate={!this.props.modal}
                       form={form}
                       mode="multiple"

--- a/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
@@ -19,7 +19,8 @@ const schema = new FormFilterSchema([
   fields.name,
   // fields.status,
   fields.parent,
-  fields.children,
+  // fields.children,
+  fields.subtaxonomies,
 ]);
 
 class TaxonomyListFilter extends Component {
@@ -76,8 +77,8 @@ class TaxonomyListFilter extends Component {
                   </Col>
                   <Col md={24} lg={12}>
                     <InputFormItem
-                      name={fields.children.name}
-                      label={fields.children.label}
+                      name={fields.subtaxonomies.name}
+                      label={fields.subtaxonomies.label}
                       layout={formItemLayout}
                     />
                   </Col>

--- a/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
@@ -19,6 +19,7 @@ const schema = new FormFilterSchema([
   fields.name,
   // fields.status,
   fields.parent,
+  fields.children,
 ]);
 
 class TaxonomyListFilter extends Component {
@@ -70,6 +71,13 @@ class TaxonomyListFilter extends Component {
                     <InputFormItem
                       name={fields.parent.name}
                       label={fields.parent.label}
+                      layout={formItemLayout}
+                    />
+                  </Col>
+                  <Col md={24} lg={12}>
+                    <InputFormItem
+                      name={fields.children.name}
+                      label={fields.children.label}
                       layout={formItemLayout}
                     />
                   </Col>

--- a/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
@@ -19,7 +19,6 @@ const schema = new FormFilterSchema([
   fields.name,
   // fields.status,
   fields.parent,
-  // fields.children,
   fields.subtaxonomies,
 ]);
 

--- a/frontend/src/view/taxonomy/list/TaxonomyListItem.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListItem.js
@@ -23,7 +23,7 @@ class TaxonomyListItem extends Component {
     if (this.props.hasPermissionToRead) {
       return (
         <div key={record.id}>
-          <Link to={`/taxonomy/${record.id}`}>
+          <Link to={`/taxonomy/${record.name}`}>
             {record['name']}
           </Link>
         </div>

--- a/frontend/src/view/taxonomy/list/TaxonomyListItem.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListItem.js
@@ -23,7 +23,7 @@ class TaxonomyListItem extends Component {
     if (this.props.hasPermissionToRead) {
       return (
         <div key={record.id}>
-          <Link to={`/taxonomy/${record.name}`}>
+          <Link to={`/taxonomy/${record.id}`}>
             {record['name']}
           </Link>
         </div>

--- a/frontend/src/view/taxonomy/list/TaxonomyListTable.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListTable.js
@@ -119,18 +119,3 @@ function select(state) {
 }
 
 export default connect(select)(TaxonomyListTable);
-
-function removeIdDuplicates(array) {
-  let ids = []; // Ids found so far
-  let filteredArray = [];
-
-  array.forEach((elem) => {
-    if (!ids.includes(elem.id)) {
-      ids.push(elem.id);
-      filteredArray.push(elem);
-    }
-  });
-  
-  return filteredArray;
-}
-

--- a/frontend/src/view/taxonomy/list/TaxonomyListTable.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListTable.js
@@ -35,7 +35,7 @@ class TaxonomyListTable extends Component {
     fields.parent.forTable({
       render: (value) => <TaxonomyListItem value={value} />,
     }),
-    fields.children.forTable({
+    fields.subtaxonomies.forTable({
       render: (value) => <TaxonomyListItem value={value} />,
     }),
     {
@@ -80,12 +80,13 @@ class TaxonomyListTable extends Component {
   };
 
   render() {
-    const { pagination, rows, loading } = this.props;
+    let { pagination, rows, loading } = this.props;
 
     return (
       <TableWrapper>
         <Table
           rowKey="id"
+          expandIcon={x => false} // Hide unwanted expandable rows
           loading={loading}
           columns={this.columns}
           dataSource={rows}
@@ -118,3 +119,18 @@ function select(state) {
 }
 
 export default connect(select)(TaxonomyListTable);
+
+function removeIdDuplicates(array) {
+  let ids = []; // Ids found so far
+  let filteredArray = [];
+
+  array.forEach((elem) => {
+    if (!ids.includes(elem.id)) {
+      ids.push(elem.id);
+      filteredArray.push(elem);
+    }
+  });
+  
+  return filteredArray;
+}
+

--- a/frontend/src/view/taxonomy/list/TaxonomyListTable.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListTable.js
@@ -35,6 +35,9 @@ class TaxonomyListTable extends Component {
     fields.parent.forTable({
       render: (value) => <TaxonomyListItem value={value} />,
     }),
+    fields.children.forTable({
+      render: (value) => <TaxonomyListItem value={value} />,
+    }),
     {
       title: '',
       dataIndex: '',

--- a/frontend/src/view/taxonomy/view/TaxonomyView.js
+++ b/frontend/src/view/taxonomy/view/TaxonomyView.js
@@ -29,8 +29,8 @@ class TaxonomyView extends Component {
         />
 
         <TaxonomyViewItem
-          label={fields.children.label}
-          value={fields.children.forView(record.parent)}
+          label={fields.subtaxonomies.label}
+          value={fields.subtaxonomies.forView(record.subtaxonomies)}
         />
 
         <TextViewItem

--- a/frontend/src/view/taxonomy/view/TaxonomyView.js
+++ b/frontend/src/view/taxonomy/view/TaxonomyView.js
@@ -28,6 +28,11 @@ class TaxonomyView extends Component {
           value={fields.parent.forView(record.parent)}
         />
 
+        <TaxonomyViewItem
+          label={fields.children.label}
+          value={fields.children.forView(record.parent)}
+        />
+
         <TextViewItem
           label={fields.createdAt.label}
           value={fields.createdAt.forView(record.createdAt)}


### PR DESCRIPTION
Adds children as an attribute of taxonomies. This enables a hierarchy of taxonomy objects, where any single taxonomy can have a number of associated parents and/or children entities.

If a child is added to a taxonomy A, this child will have A as one of its parents, and vice versa. This symmetry should also hold for updating and deletion of taxonomies.

Currently there is no limitation to what entities are eligible as parents or children, e.g. at the moment there is no cycle prevention or blocking of taxonomies being parents/children of themselves.

Adding a new taxonomy with a new child:
![image](https://user-images.githubusercontent.com/35490347/115223738-6c161c80-a10c-11eb-8e04-447dc240b54b.png)

After adding a parent-child relationship between two taxonomies Parent and Child1:
![image](https://user-images.githubusercontent.com/35490347/115223814-805a1980-a10c-11eb-821c-88205647d27f.png)

After editing Parent to also have Child2 as a child:
![image](https://user-images.githubusercontent.com/35490347/115223943-a4b5f600-a10c-11eb-9aa5-ee751fe1d389.png)

After deleting Child1: 
![image](https://user-images.githubusercontent.com/35490347/115224032-b6979900-a10c-11eb-8fca-89db1de6c762.png)



