### PR TITLE
Require that taxonomies have names

### DIFF
--- a/backend/src/api/taxonomy/types/taxonomy.js
+++ b/backend/src/api/taxonomy/types/taxonomy.js
@@ -3,7 +3,7 @@ const TaxonomyService = require('../../../services/taxonomyService');
 const schema = `
   type Taxonomy {
     id: String!
-    name: String
+    name: String!
     parent: [Taxonomy!]
     createdAt: DateTime
     updatedAt: DateTime

--- a/backend/src/database/models/taxonomy.js
+++ b/backend/src/database/models/taxonomy.js
@@ -14,7 +14,7 @@ const TaxonomySchema = new Schema(
     parent: [
       {
         type: Schema.Types.ObjectId,
-        // ref: 'taxonomy',
+        ref: 'taxonomy',
       },
     ],
   }


### PR DESCRIPTION
Minor fix to avoid creating taxonomies without names.