### PR TITLE
Make taxonomies searchable by parent

### DIFF
--- a/backend/src/api/taxonomy/types/taxonomyFilterInput.js
+++ b/backend/src/api/taxonomy/types/taxonomyFilterInput.js
@@ -2,7 +2,7 @@ const schema = `
   input TaxonomyFilterInput {
     id: String
     name: String
-    parent: [String!]
+    parent: String
     status: TaxonomyStatusEnum
     createdAtRange: [ DateTime ]
   }

--- a/backend/src/database/repositories/taxonomyRepository.js
+++ b/backend/src/database/repositories/taxonomyRepository.js
@@ -238,11 +238,24 @@ class TaxonomyRepository {
         };
       }
 
-      // TODO fix filtering on parent
       if (filter.parent) {
+        // Get the list of taxonomies
+        // that has a name that satisfies the parent filter
+        const parentTaxonomies = await Taxonomy.find({
+          name: {
+            $regex: MongooseQueryUtils.escapeRegExp(
+              filter.parent,
+            ),
+            $options: 'i',
+          },
+        })
+        // Then extract the IDs of these taxonomies,
+        // and check if any taxonomies have these IDs
+        // in their parent lists
+        const parentIds = parentTaxonomies.map(item => item._id)
         criteria = {
           ...criteria,
-          parent: filter.parent,
+          parent: { $in: parentIds },
         };
       }
 

--- a/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
+++ b/frontend/src/view/taxonomy/list/TaxonomyListFilter.js
@@ -17,7 +17,6 @@ const { fields } = model;
 
 const schema = new FormFilterSchema([
   fields.name,
-  // fields.status,
   fields.parent,
 ]);
 
@@ -35,9 +34,8 @@ class TaxonomyListFilter extends Component {
   };
 
   handleSubmit = (values) => {
-    const valuesToSubmit = schema.cast(values);
     const { dispatch } = this.props;
-    dispatch(actions.doFetch(valuesToSubmit));
+    dispatch(actions.doFetch(values));
   };
 
   handleReset = (form) => {


### PR DESCRIPTION
This commit enables the user to enter the name of a taxonomy (or a substring of a name) into the `parent` search field and get all taxonomies that have a parent with a name that satisfies the search criteria. That is, if we have the following taxonomies
![image](https://user-images.githubusercontent.com/35490347/125831321-3f21828b-78d8-4f98-937f-bdfb6bf7238b.png)
we should be able to write "adhd" into the `parent` search field and get this:
![image](https://user-images.githubusercontent.com/35490347/125831348-7763bab8-6071-495e-b94d-54cc945d8933.png)

